### PR TITLE
chore(issue-3): scaffold migrate dashboard to useAppStore

### DIFF
--- a/frontend/MIGRATE_DASHBOARD.md
+++ b/frontend/MIGRATE_DASHBOARD.md
@@ -1,0 +1,20 @@
+MIGRATION TASK — Migrate Dashboard to useAppStore
+
+Goal
+- Move dashboard image pagination and list state into the central `useAppStore` (Zustand) and add tests to assert append/replace behavior.
+
+Scope
+- Hooks: `useDashboard` (read/write images, page, loading, error)
+- Components: `DashboardView`, `ImagesTable` (if needed)
+- Tests: unit tests for store actions and hook behavior; small integration test for DashboardView.
+
+Checklist
+- [ ] Update `useDashboard` to use `useAppStore` selectors and actions.
+- [ ] Add unit tests for append/replace behavior (page === 1 replace, page > 1 append).
+- [ ] Update `DashboardView` to remove prop-drilling and use store.
+- [ ] Run test suite and ensure green.
+
+Notes
+- Be careful with React Strict Mode double-mount: prefer replace on page 1.
+- Keep Zod validation on API layer unchanged.
+


### PR DESCRIPTION
This PR introduces a small migration scaffold for dashboard migration to `useAppStore`.

Files added:
- `MIGRATE_DASHBOARD.md` (plan + checklist)

Next steps in this PR series:
- Update `useDashboard` to use store selectors/actions
- Add unit tests for append/replace behavior
- Update `DashboardView` to remove prop drilling

Related: PR #18 (migration plan)
